### PR TITLE
✨ zoom-out 으로  컴포넌트와 날짜 데이터 로직 구현

### DIFF
--- a/src/components/YearDot/index.jsx
+++ b/src/components/YearDot/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 
 import * as d3 from "d3";
@@ -7,6 +8,7 @@ import styled from "styled-components";
 import { daysListState } from "../../lib/recoil/days";
 
 function YearDot() {
+  const navigate = useNavigate();
   const svgRef = useRef();
   const userOneYearData = useRecoilValue(daysListState);
 
@@ -18,13 +20,19 @@ function YearDot() {
       .select(svgRef.current)
       .append("svg")
       .attr("class", "year-board")
-      .attr("viewBox", [0, 0, width, height - 70]);
+      .attr("viewBox", [0, 0, width, height - 70])
+      .on("wheel", event => {
+        const zoomScale = svg._groups[0][0].__zoom.k;
+
+        if (zoomScale < 1) {
+          navigate("/life", { replace: false, state: "year" });
+        }
+      });
 
     const gDay = svg
       .append("g", "year-board")
       .attr("class", "day-dots")
       .attr("transform", `translate(${0},${0})`);
-
     const dayDots = gDay
       .selectAll("circle")
       .data(userOneYearData)
@@ -38,8 +46,6 @@ function YearDot() {
       .attr("stroke-width", 0.003)
       .attr("opacity", 0.5)
       .on("mouseover", event => {
-        const zoomScale = svg._groups[0][0].__zoom.k;
-        const targetDate = event.target.getAttribute("class");
         event.target.style.fill = "deeppink";
       })
       .on("mouseout", event => {

--- a/src/lib/recoil/coords/atom.js
+++ b/src/lib/recoil/coords/atom.js
@@ -1,0 +1,12 @@
+import { atom } from "recoil";
+
+const dotCoordsState = atom({
+  key: "dotCoordsState",
+  default: {
+    x: 0,
+    y: 0,
+    k: 1,
+  },
+});
+
+export default dotCoordsState;

--- a/src/lib/recoil/coords/index.js
+++ b/src/lib/recoil/coords/index.js
@@ -1,0 +1,3 @@
+import dotCoordsState from "./atom";
+
+export default dotCoordsState;


### PR DESCRIPTION
## Task Card
- [[day 페이지] - mouse hover](https://taewan.notion.site/day-mouse-hover-a093ceb752e94bd0b386f1d336593d03)

## Description
- zoom-out 을 했을 경우 year 페이지로 UI 변화 

## Key Points
- 현재 좌표와 스케일 (x, y, k) 값 3 개를 zoom 위치로써 전역상태로 관리 -> zoom-out 으로 페이지 이동할 때 기억해둔 좌표와 스케일 값을 활용해서 이전 페이지 위치 표시
- 하지만 현재 viewport 에 responsive 하게 대응하려면 (x, y, k) 의 값들을 전부 viewport 를 활용해서 계산하는 로직 구현이 필요할 듯 싶은데, 추후에 구현할 수 있다면 참 좋을 듯 싶다.!
- zoom `wheel` 뿐만 아니라 마우스 커서로 svg 내에서 이동한 경우 일어나는 버그 대응도 필요할 듯 싶다

## Checklist - reusable and pure functions
- [x] Is everything function needs specified as parameters?
- [ ] Is function reusable (cacheable) and pure? (If it's possible)
 - No random values
 - No current date/time
 - No global state (DOM, files, db, etc)
 - No mutation of parameters
