### PR TITLE
🐛 유저 생일 년도 날짜 계산 로직 버그 수정

### DIFF
--- a/src/components/LifeDot/index.jsx
+++ b/src/components/LifeDot/index.jsx
@@ -86,8 +86,6 @@ function LifeDot() {
           );
         }
 
-        console.log(zoomScale);
-
         if (zoomScale > 80000) {
           setDotCoords({
             x: 0,

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 import { GrFormClose } from "react-icons/gr";
 
 import loginState from "../../lib/recoil/auth";
-import birthday from "../../lib/recoil/userYears";
+import birthday, { hundredyearsListState } from "../../lib/recoil/userYears";
 
 import { login } from "../../lib/api";
 import config from "../../lib/config";
@@ -19,6 +19,7 @@ function Login() {
 
   const dateOfBirth = useRecoilValue(birthday);
   const setLoginState = useSetRecoilState(loginState);
+  const setUserHundredYearsData = useSetRecoilState(hundredyearsListState);
   const loginMutation = useMutation(login);
 
   const decodeJWT = token => {
@@ -36,6 +37,7 @@ function Login() {
         onSuccess: ({ data }) => {
           setLoginState(data);
           localStorage.setItem("loginData", JSON.stringify(data));
+          setUserHundredYearsData(data.data.dateOfBirth);
 
           hideModal();
           navigate("/life", { replace: true });

--- a/src/lib/recoil/targetYear/targetYearDaysListState.js
+++ b/src/lib/recoil/targetYear/targetYearDaysListState.js
@@ -12,7 +12,8 @@ const targetYearDaysListState = selector({
     const userBirthday = get(birthdayState);
 
     const datesOfTargetYear = calDatesOfYear(userBirthday, targetYear);
-    const userTargetYearData = calDatesData(datesOfTargetYear) || [];
+    const userTargetYearData =
+      calDatesData(datesOfTargetYear, targetYear, userBirthday) || [];
 
     return userTargetYearData;
   },

--- a/src/lib/utils/calDatesData.js
+++ b/src/lib/utils/calDatesData.js
@@ -1,8 +1,21 @@
-export default function calDatesData(datesOfTargetYear) {
+export default function calDatesData(
+  datesOfTargetYear,
+  targetYear,
+  userBirthDay,
+) {
   const oneYearData = [];
   let curMonth = 1;
   let col = 1;
   let row = 1;
+
+  const { year, month, date } = userBirthDay;
+  const birthYear = year;
+  const birthMonth = month;
+  const birthDate = date;
+
+  if (targetYear === birthYear) {
+    col = birthMonth - 1;
+  }
 
   datesOfTargetYear.forEach(targetDate => {
     const { year, month, date } = targetDate;
@@ -12,6 +25,10 @@ export default function calDatesData(datesOfTargetYear) {
       col++;
       row = 1;
       curMonth = month;
+    }
+
+    if (year === birthYear && month === birthMonth && row < birthDate) {
+      row += birthDate - 1;
     }
 
     oneYearData.push({

--- a/src/lib/utils/createAxis.js
+++ b/src/lib/utils/createAxis.js
@@ -32,12 +32,12 @@ export default function createAxis(gElements, axisType, id) {
     ];
 
     const elementGroup = document.querySelector(`${id}`);
-    const yAxisWidth = elementGroup.getBBox().width;
+    const xAxisWidth = elementGroup.getBBox().width;
 
     const xAxisScale = d3
       .scalePoint()
       .domain(xAxisData)
-      .range([1, yAxisWidth - yAxisWidth / 15]);
+      .range([1, xAxisWidth - xAxisWidth / 15]);
 
     axis = d3.axisTop(xAxisScale);
   }

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -2,7 +2,6 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import styled from "styled-components";
 
-import loginState from "../../lib/recoil/auth";
 import birthdayState, {
   hundredyearsListState,
 } from "../../lib/recoil/userYears";
@@ -21,7 +20,6 @@ function MainPage() {
     birthDate: date,
   });
 
-  const loginData = useRecoilValue(loginState);
   const { showModal } = useModal();
 
   const handleWheelChange = e => {
@@ -32,19 +30,11 @@ function MainPage() {
   const handleSubmit = e => {
     e.preventDefault();
 
-    if (loginData) {
-      setUserHundredYearsData({
-        year,
-        month,
-        date,
-      });
-    } else {
-      setUserHundredYearsData({
-        year: birthYear,
-        month: birthMonth,
-        date: birthDate,
-      });
-    }
+    setUserHundredYearsData({
+      year: birthYear,
+      month: birthMonth,
+      date: birthDate,
+    });
   };
 
   const handleLoginClick = () => {


### PR DESCRIPTION
## Task Card
- 

## Description
- 유저의 생일 년도가 월에 따라 YearDot 컴포넌트에서 날짜의 col, row 포지션이 잘못되어 렌더링되는 버그 수정
- dates data 를 계산하는 로직 유틸함수를 필요한 값들을 모두 인자로 받는 순수함수로 구현했기 때문에, 버그를 늦게 발견했지만 그래도 더 간편하게 버그를 수정할 수 있었음

## Key Points
- calDatesData 의 birthYear 관련 계산 로직

## Checklist - reusable and pure functions
- [x] Is everything function needs specified as parameters?
- [x] Is function reusable (cacheable) and pure? (If it's possible)
 - No random values
 - No current date/time
 - No global state (DOM, files, db, etc)
 - No mutation of parameters
